### PR TITLE
feat: add health check for services + docker file update

### DIFF
--- a/analyser/cmd/analyser/main.go
+++ b/analyser/cmd/analyser/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/EricMurray-e-m-dev/StartupMonkey/analyser/internal/detector"
 	"github.com/EricMurray-e-m-dev/StartupMonkey/analyser/internal/engine"
 	grpcserver "github.com/EricMurray-e-m-dev/StartupMonkey/analyser/internal/grpc"
+	"github.com/EricMurray-e-m-dev/StartupMonkey/analyser/internal/health"
 	pb "github.com/EricMurray-e-m-dev/StartupMonkey/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -37,6 +38,7 @@ func main() {
 	reflection.Register(grpcServer)
 
 	log.Printf("Analyser listening on 50051")
+	health.StartHealthCheckServer("8081")
 
 	if err := grpcServer.Serve(listener); err != nil {
 		log.Fatalf("Failed to serve: %v", err)

--- a/analyser/internal/health/server.go
+++ b/analyser/internal/health/server.go
@@ -1,0 +1,46 @@
+package health
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+var startTime time.Time
+
+func init() {
+	startTime = time.Now()
+}
+
+type HealthResponse struct {
+	Status        string `json:"status"`
+	Service       string `json:"service"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+func StartHealthCheckServer(port string) {
+	http.HandleFunc("/health", healthHandler)
+
+	log.Printf("Health check listening on : %s", port)
+
+	go func() {
+		if err := http.ListenAndServe(":"+port, nil); err != nil {
+			log.Fatalf("Health server failed: %v", err)
+		}
+	}()
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	response := &HealthResponse{
+		Status:        "healthy",
+		Service:       "analyser",
+		UptimeSeconds: int64(time.Since(startTime).Seconds()),
+		Timestamp:     int64(time.Now().Unix()),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}

--- a/collector/cmd/collector/main.go
+++ b/collector/cmd/collector/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/EricMurray-e-m-dev/StartupMonkey/collector/internal/config"
+	"github.com/EricMurray-e-m-dev/StartupMonkey/collector/internal/health"
 	"github.com/EricMurray-e-m-dev/StartupMonkey/collector/internal/orchestrator"
 )
 
@@ -35,6 +36,8 @@ func main() {
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	health.StartHealthCheckServer("8080")
 
 	go func() {
 		if err := orch.Run(ctx); err != nil && err != context.Canceled {

--- a/collector/internal/health/server.go
+++ b/collector/internal/health/server.go
@@ -1,0 +1,46 @@
+package health
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+var startTime time.Time
+
+func init() {
+	startTime = time.Now()
+}
+
+type HealthResponse struct {
+	Status        string `json:"status"`
+	Service       string `json:"service"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+func StartHealthCheckServer(port string) {
+	http.HandleFunc("/health", healthHandler)
+
+	log.Printf("Health check listening on : %s", port)
+
+	go func() {
+		if err := http.ListenAndServe(":"+port, nil); err != nil {
+			log.Fatalf("Health server failed: %v", err)
+		}
+	}()
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	response := &HealthResponse{
+		Status:        "healthy",
+		Service:       "collector",
+		UptimeSeconds: int64(time.Since(startTime).Seconds()),
+		Timestamp:     int64(time.Now().Unix()),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}

--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/EricMurray-e-m-dev/StartupMonkey/executor/internal/eventbus"
 	grpcserver "github.com/EricMurray-e-m-dev/StartupMonkey/executor/internal/grpc"
 	"github.com/EricMurray-e-m-dev/StartupMonkey/executor/internal/handler"
+	"github.com/EricMurray-e-m-dev/StartupMonkey/executor/internal/health"
 	pb "github.com/EricMurray-e-m-dev/StartupMonkey/proto"
 )
 
@@ -48,6 +49,7 @@ func main() {
 	pb.RegisterExecutorServiceServer(grpcServer, executorServer)
 
 	log.Printf("Executor gRPC server listening on :%s", grpcPort)
+	health.StartHealthCheckServer("8082")
 
 	// Handle shutdown on signal
 	go func() {

--- a/executor/internal/health/server.go
+++ b/executor/internal/health/server.go
@@ -1,0 +1,46 @@
+package health
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+var startTime time.Time
+
+func init() {
+	startTime = time.Now()
+}
+
+type HealthResponse struct {
+	Status        string `json:"status"`
+	Service       string `json:"service"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+func StartHealthCheckServer(port string) {
+	http.HandleFunc("/health", healthHandler)
+
+	log.Printf("Health check listening on : %s", port)
+
+	go func() {
+		if err := http.ListenAndServe(":"+port, nil); err != nil {
+			log.Fatalf("Health server failed: %v", err)
+		}
+	}()
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	response := &HealthResponse{
+		Status:        "healthy",
+		Service:       "executor",
+		UptimeSeconds: int64(time.Since(startTime).Seconds()),
+		Timestamp:     int64(time.Now().Unix()),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}


### PR DESCRIPTION
# Summary
- Added `internal/health/server.go` in each service
- Simple REST end point for health check
- Updated docker compose to spin up all 3 services + NATs for event bus
- Added `Dockerfile` for `executor`

# Closes
Closes #29 