### PR TITLE
Fix Rollback Bug & Update Settings

### DIFF
--- a/dashboard/app/api/actions/[id]/rollback/route.ts
+++ b/dashboard/app/api/actions/[id]/rollback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const COLLECTOR_URL = process.env.COLLECTOR_URL || "http://localhost:3001";
+const EXECUTOR_URL = process.env.EXECUTOR_URL || "http://localhost:8084";
 
 export async function POST(
     request: NextRequest,
@@ -9,7 +9,9 @@ export async function POST(
     try {
         const { id } = await params;
 
-        const response = await fetch(`${COLLECTOR_URL}/actions/${id}/rollback`, {
+        console.log(`Rolling back action: ${id}`);
+
+        const response = await fetch(`${EXECUTOR_URL}/api/actions/${id}/rollback`, {
             method: "POST",
         });
 

--- a/dashboard/app/settings/page.tsx
+++ b/dashboard/app/settings/page.tsx
@@ -72,6 +72,12 @@ const WEBHOOK_EVENTS = [
     { id: "action.rolledback", label: "Action Rolled Back" },
 ];
 
+const CONNECTION_STRING_PLACEHOLDERS: Record<string, string> = {
+    postgres: "postgresql://user:password@host:5432/database",
+    mysql: "mysql://user:password@host:3306/database",
+    mongodb: "mongodb://user:password@host:27017/database?authSource=admin",
+};
+
 const EMPTY_DATABASE: DatabaseEntry = {
     database_id: "",
     database_name: "",
@@ -181,6 +187,14 @@ export default function SettingsPage() {
             ...prev,
             database_name: name,
             database_id: editingDatabase ? prev.database_id : generateDatabaseId(name),
+        }));
+    };
+
+    const handleDatabaseTypeChange = (type: string) => {
+        setDatabaseForm(prev => ({
+            ...prev,
+            database_type: type,
+            connection_string: editingDatabase ? prev.connection_string : '',
         }));
     };
 
@@ -519,9 +533,7 @@ export default function SettingsPage() {
                             <Label htmlFor="dialog-db-type">Database Type</Label>
                             <Select
                                 value={databaseForm.database_type}
-                                onValueChange={(value) =>
-                                    setDatabaseForm((prev) => ({ ...prev, database_type: value }))
-                                }
+                                onValueChange={handleDatabaseTypeChange}
                                 disabled={!!editingDatabase}
                             >
                                 <SelectTrigger>
@@ -529,7 +541,8 @@ export default function SettingsPage() {
                                 </SelectTrigger>
                                 <SelectContent>
                                     <SelectItem value="postgres">PostgreSQL</SelectItem>
-                                    <SelectItem value="mysql" disabled>MySQL (coming soon)</SelectItem>
+                                    <SelectItem value="mysql">MySQL</SelectItem>
+                                    <SelectItem value="mongodb">MongoDB</SelectItem>
                                 </SelectContent>
                             </Select>
                         </div>
@@ -539,7 +552,7 @@ export default function SettingsPage() {
                             <Input
                                 id="dialog-conn-string"
                                 type="password"
-                                placeholder="postgresql://user:password@host:5432/database"
+                                placeholder={CONNECTION_STRING_PLACEHOLDERS[databaseForm.database_type] || CONNECTION_STRING_PLACEHOLDERS.postgres}
                                 value={databaseForm.connection_string}
                                 onChange={(e) =>
                                     setDatabaseForm((prev) => ({ ...prev, connection_string: e.target.value }))


### PR DESCRIPTION
This pull request updates the rollback API route to use the correct executor service and improves the database settings page by supporting additional database types and enhancing the user experience when adding or editing databases.

**API Integration Updates:**

* Changed the rollback API endpoint in `dashboard/app/api/actions/[id]/rollback/route.ts` to use `EXECUTOR_URL` instead of `COLLECTOR_URL`, and updated the target URL to `/api/actions/${id}/rollback`. Added a console log for rollback actions. ([dashboard/app/api/actions/[id]/rollback/route.tsL3-R3](diffhunk://#diff-c5344030d89a12ea76b9874de226552a3dd712772c709489944de4388e85385dL3-R3), [dashboard/app/api/actions/[id]/rollback/route.tsL12-R14](diffhunk://#diff-c5344030d89a12ea76b9874de226552a3dd712772c709489944de4388e85385dL12-R14))

**Database Settings Improvements:**

* Added support for MySQL and MongoDB database types in the settings page, including updating the database type selector and enabling selection of these types.
* Introduced dynamic connection string placeholders for each database type to guide users with the correct format. The placeholder updates based on the selected database type. [[1]](diffhunk://#diff-71d4b1d11c571fe3c2308c34c7ddfa1277350bdf13770da23cb2072cbd3faacbR75-R80) [[2]](diffhunk://#diff-71d4b1d11c571fe3c2308c34c7ddfa1277350bdf13770da23cb2072cbd3faacbL542-R555)
* Refactored the database type change handler to reset the connection string when adding a new database, improving the add/edit database form UX.


Closes #148, #149 