### PR TITLE
hotfix: updated release action follow new context for dash coll proto

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Build and push Dashboard Collector
         uses: docker/build-push-action@v5
         with:
-          context: ./dashboard
+          context: .
           file: ./dashboard/Dockerfile.collector
           push: true
           tags: |


### PR DESCRIPTION
This pull request makes a small adjustment to the release workflow configuration. The build context for the Dashboard Collector Docker image is changed from the `dashboard` subdirectory to the repository root. This ensures the Docker build process has access to the entire repository context if needed.

* Changed the Docker build context for the Dashboard Collector in `.github/workflows/release.yml` from `./dashboard` to `.`.